### PR TITLE
Update 0.21.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dulwich" %}
-{% set version = "0.21.2" %}
-{% set sha256 = "d865ae7fd9497d64ce345a6784ff1775b01317fba9632ef9d2dfd7978f1b0d4f" %}
+{% set version = "0.21.3" %}
+{% set sha256 = "7ca3b453d767eb83b3ec58f0cfcdc934875a341cdfdb0dc55c1431c96608cf83" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,9 @@ requirements:
     - wheel
   run:
     - python
-    - urllib3 >=1.23
+    - urllib3 >=1.25
+  run_constrained:
+    - paramiko
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,26 +24,17 @@ requirements:
   host:
     - python
     - pip
-    - urllib3
-    # secure
-    - pyopenssl >=0.14
-    - cryptography >=1.3.4
-    - idna >=2.0.0
-    - certifi
-    - ipaddress  # [py<=33]
-    - pysocks >=1.5.6,<2.0,!=1.5.7
+    - setuptools
+    - wheel
   run:
     - python
-    - urllib3
-    # secure
-    - pyopenssl >=0.14
-    - cryptography >=1.3.4
-    - idna >=2.0.0
-    - certifi
-    - ipaddress  # [py<=33]
-    - pysocks >=1.5.6,<2.0,!=1.5.7
+    - urllib3 >=1.23
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - dulwich
     - dulwich.tests
@@ -77,7 +68,6 @@ about:
   license_family: Apache
   license_file: COPYING
   summary: Python Git Library
-
   description: |
     Python implementation of the Git file formats and protocols, without the need to have git installed.
     All functionality is available in pure Python. Optional C extensions can be built for improved performance.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<38]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,6 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - python


### PR DESCRIPTION
[Upstream](https://github.com/jelmer/dulwich)
[Changelog](https://github.com/jelmer/dulwich/releases)

### Actions
- Update version number and sha256
- Add `py<38` build skip
- Update dependencies
- Linter fixes