### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: true  # [py<38]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dulwich" %}
-{% set version = "0.21.3" %}
-{% set sha256 = "7ca3b453d767eb83b3ec58f0cfcdc934875a341cdfdb0dc55c1431c96608cf83" %}
+{% set version = "0.22.7" %}
+{% set sha256 = "d53935832dd182d4c1415042187093efcee988af5cd397fb1f394f5bb27f0707" %}
 
 package:
   name: {{ name|lower }}
@@ -12,23 +12,23 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [py<38]
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: true  # [py<39]
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('rust') }}
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=61.2
     - wheel
+    - setuptools-rust
   run:
     - python
     - urllib3 >=1.25
-  run_constrained:
-    - paramiko
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,6 @@ test:
   imports:
     - dulwich
     - dulwich.tests
-    - dulwich.tests.compat
     - dulwich.tests.utils
     - dulwich.archive
     - dulwich.client

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   skip: true  # [py<39]
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1  # [s390x]
 
 requirements:
   build:


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

Update to 0.22.7
https://github.com/jelmer/dulwich/tree/dulwich-0.22.7